### PR TITLE
adds (short-term) universal wheel support; increase test tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install:
 - pip install python-coveralls tox tox-travis
 script: tox --recreate
@@ -18,4 +19,4 @@ deploy:
   password:
     secure: "m6n470zn8+lLDoB0W/goO3ovoMScb7sVWRQcXtm7V99YtxgBzqDT+xy4nPfEeRj/0FHSL2/k9xJHV4Q8l+UfjGFR6fszXPKkSgeL4KfE0r5GuVDNIRu853f5Pa7DM8l4GNn6/NP9Lv+jVD79j8Edb4nJgTWvxOnj9PvDZJnxqjk="
   on:
-    python: 2.7
+    python: 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
increases the "official" interpreters, but really just allowing universal wheels (at least for the short term).

since the build is failing only on py3.4 (which is a PyYAML issue), I would argue we can short-term support 3.4 (since we're not changing any internals in this PR), and once on py3, probably go 3.5-3.8. It's a bit outside the scope of this change, but since the build failed on something unrelated to the project, I did want to bring it up.